### PR TITLE
Added option to show carrier name in messages

### DIFF
--- a/LsoBot/LsoBot-Config.psd1
+++ b/LsoBot/LsoBot-Config.psd1
@@ -34,6 +34,11 @@ Carrier Strike Group 8 - https://discord.gg/9h9QUA8
 
         Accepts: "embed" or "basic"
         Fallback: "basic"
+
+    $showCarrier = Whether to display the name of the carrier in landing grades. Useful in missions with many carriers.
+
+        Accepts: $true or $false
+        Fallback: $false
 #>
 
 @{
@@ -48,5 +53,7 @@ Carrier Strike Group 8 - https://discord.gg/9h9QUA8
     underlineStyle = "Underline" 
 
     hookStyle = "embed"   
+
+    showCarrier = $false
 
 }

--- a/LsoBot/LsoBot.ps1
+++ b/LsoBot/LsoBot.ps1
@@ -294,6 +294,11 @@ for ($i = 1; $i -le $timeTarget; $i++) {
     $Pilot = $Pilot -replace "^.*(?:initiatorPilotName=)", ""
     $Pilot = $Pilot -replace ",.*$", ""
 
+    #Strip the log message down to the carrier name
+    $Carrier = $landingEvent
+    $Carrier = $Carrier -replace "^.*(?:place=)", ""
+    $Carrier = $Carrier -replace ",.*$", ""
+
     #Strip the log message down to the landing grade and add escapes for _
     $Grade = $landingEvent
     $Grade = $Grade -replace "^.*(?:comment=LSO:)", ""
@@ -802,6 +807,17 @@ for ($i = 1; $i -le $timeTarget; $i++) {
                         inline = $true
                         }
                     )
+                }
+
+                #Add carrier field if enabled
+                if ($lsoConfig.showCarrier -eq $true) {
+                    $carrierField = [PSCustomObject]@{
+                        name = "**Carrier**"
+                        value = $Carrier
+                        inline = $true
+                    }
+                    $fields = $hookEmbedObject.fields
+                    $hookEmbedObject.fields = $fields[0], $carrierField + @($fields[1..($fields.count-1)])
                 }
 
                 #Add embed object to array


### PR DESCRIPTION
Because the server I co-manage runs a mission with several carriers where players can land on, I added a new setting to display of the name of the carrier in messages, and I think this could be useful on other servers as well. This is my first rodeo with PowerShell, so feedback on any mistakes is appreciated.

The carrier name field is inserted near the start of the message, after the pilot name. Example:
![image](https://user-images.githubusercontent.com/6194377/147485534-deb1435e-8455-4274-af11-ecac422aec26.png)
